### PR TITLE
Update file paniere_reti.json

### DIFF
--- a/quiz_bot/quizzes/paniere_reti.json
+++ b/quiz_bot/quizzes/paniere_reti.json
@@ -1658,7 +1658,7 @@
     "question": "In RSA , a quanto equivale ϕ(n):",
     "answers": [
       "P*q",
-      "(p-1)*(q-1)",
+      "(p+1)*(q+1)",
       "P*(q-1)",
       "(p-1)*(q-1)"
     ],


### PR DESCRIPTION
Risolto typo: risposta doppia (probabilmente un refuso dal paniere in PDF)

BOT:
<img width="341" height="167" alt="image" src="https://github.com/user-attachments/assets/9a8fab49-a3bd-459d-8f63-dd9a54c190ba" />
Selezionando l'opzione corretta, (p-1)+(q-1) si è ottenuto un errore.

Contenuto reti_di_calcolatori.pdf
<img width="281" height="121" alt="image" src="https://github.com/user-attachments/assets/9f2285d7-d17a-4c0c-a861-683cd9b179f6" />

Test di fine lezione (con opzioni corrette):
<img width="1036" height="260" alt="image" src="https://github.com/user-attachments/assets/05f0753e-2a31-452a-9f2d-5ecb263ed49d" />

